### PR TITLE
[Basic] Index Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+*.sln.DotSettings.user

--- a/CodingBunny.ElasticBunny/ElasticClient.cs
+++ b/CodingBunny.ElasticBunny/ElasticClient.cs
@@ -1,0 +1,74 @@
+﻿using CodingBunny.ElasticBunny.Interfaces;
+using CodingBunny.ElasticBunny.Types;
+using Index = CodingBunny.ElasticBunny.Types.Index;
+
+namespace CodingBunny.ElasticBunny;
+
+/// <summary>
+/// Concrete implementation of the <see cref="IElasticClient"/> interface, providing a default implementation using the
+/// <c>System.Net.Http</c> and <c>System.Text.Json</c> libraries of the .NET Framework. 
+/// </summary>
+public class ElasticClient : IElasticClient, IDisposable
+{
+    /// <summary>
+    /// The <see cref="IConnectionSettings"/> to control the HTTP Client to communicate with ElasticSearch
+    /// </summary>
+    private readonly IConnectionSettings _connectionSettings;
+    
+    private readonly HttpClient _httpClient = new();
+
+    /// <summary>
+    /// Flag to track whether the object has been disposed or not.
+    /// </summary>
+    private volatile bool _disposed;
+    
+    /// <summary>
+    /// Creates a new instance of the <see cref="ElasticClient"/> class with the default settings applied.
+    /// </summary>
+    public ElasticClient() : this(new ConnectionSettings())
+    { }
+    
+    /// <summary>
+    /// Creates a new instance of the <see cref="ElasticClient"/> class with the provided <see cref="IConnectionSettings"/>.
+    /// </summary>
+    /// <param name="connectionSettings">The <see cref="IConnectionSettings"/> for the HTTP Client.</param>
+    public ElasticClient(IConnectionSettings connectionSettings)
+    {
+        _connectionSettings = connectionSettings;
+    }
+    
+    /// <inheritdoc cref="IIndexExists.Exists"/>
+    public bool Exists(Index name)
+    {
+        return false;
+    }
+    
+    /// <inheritdoc cref="IIndexExists.ExistsAsync"/>
+    public Task<bool> ExistsAsync(Index name)
+    {
+        return new Task<bool>(() => false);
+    }
+
+    /// <summary>
+    /// Disposes the object, releasing all resources claimed by the instance.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        
+        _httpClient.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Raises an <see cref="ObjectDisposedException"/> if the object has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the object has been disposed.</exception>
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException("ElasticClient instance has been disposed.");
+        }
+    }
+}

--- a/CodingBunny.ElasticBunny/Interfaces/IConnectionSettings.cs
+++ b/CodingBunny.ElasticBunny/Interfaces/IConnectionSettings.cs
@@ -1,0 +1,14 @@
+﻿namespace CodingBunny.ElasticBunny.Interfaces;
+
+/// <summary>
+/// This interface forms the functional contract to which all connection settings must adhere.
+/// This allows us to swap implementations for various clients and/or behaviors, depending on the need
+/// of the user.
+/// </summary>
+public interface IConnectionSettings
+{
+    /// <summary>
+    /// The <see cref="Uri"/> of the ElasticSearch instance.
+    /// </summary>
+    public Uri Url { get; set; }
+}

--- a/CodingBunny.ElasticBunny/Interfaces/IElasticClient.cs
+++ b/CodingBunny.ElasticBunny/Interfaces/IElasticClient.cs
@@ -1,16 +1,11 @@
 ﻿using CodingBunny.ElasticBunny.Types;
 
-namespace CodingBunny.ElasticBunny;
+namespace CodingBunny.ElasticBunny.Interfaces;
 
 /// <summary>
 /// This interface forms the main functional contract that clients need to adhere to inside the framework.
 /// Every client is expected to offer this functionality, which maps more or less to the functionality provided
 /// by ElasticSearch itself over their REST API.
 /// </summary>
-public interface IElasticClient
-{
-    public bool IndexExists(IndexName name);
-
-    public Task<bool> IndexExistsAsync(IndexName name);
-    
-}
+public interface IElasticClient : IIndexExists
+{ }

--- a/CodingBunny.ElasticBunny/Interfaces/IIndexExists.cs
+++ b/CodingBunny.ElasticBunny/Interfaces/IIndexExists.cs
@@ -1,0 +1,25 @@
+﻿using Index = CodingBunny.ElasticBunny.Types.Index;
+
+namespace CodingBunny.ElasticBunny.Interfaces;
+
+/// <summary>
+/// This interface provides the functionality to determine whether an <see cref="Index"/> actually exists
+/// inside the ElasticSearch cluster.
+/// </summary>
+public interface IIndexExists
+{
+    /// <summary>
+    /// Returns <c>true</c> if the <see cref="Index"/> exists inside the ElasticSearch cluster, <c>false</c> otherwise.
+    /// </summary>
+    /// <param name="name">The <see cref="Index"/> to verify in the ElasticSearch cluster.</param>
+    /// <returns>A <see cref="bool"/> representing the logical outcome of the check.</returns>
+    public bool Exists(Index name);
+
+    /// <summary>
+    /// Performs an asynchronous operation to determine whether the <see cref="Index"/> exists inside
+    /// the ElasticSearch cluster and returns the result.
+    /// </summary>
+    /// <param name="name">The <see cref="Index"/> to verify in the ElasticSearch cluster.</param>
+    /// <returns>A <see cref="Task"/> with the <see cref="bool"/> result of the check.</returns>
+    public Task<bool> ExistsAsync(Index name);
+}

--- a/CodingBunny.ElasticBunny/Types/ConnectionSettings.cs
+++ b/CodingBunny.ElasticBunny/Types/ConnectionSettings.cs
@@ -1,0 +1,14 @@
+﻿using CodingBunny.ElasticBunny.Interfaces;
+
+namespace CodingBunny.ElasticBunny.Types;
+
+/// <summary>
+/// Concrete implementation of the <see cref="IConnectionSettings"/> for the HTTP Client.
+/// This class contains all information needed to actually connect to an ElasticSearch cluster, as well as control
+/// how the HTTP Client acts.
+/// </summary>
+public class ConnectionSettings : IConnectionSettings
+{
+    /// <inheritdoc cref="IConnectionSettings.Url"/>
+    public Uri Url { get; set; }
+}

--- a/CodingBunny.ElasticBunny/Types/Index.cs
+++ b/CodingBunny.ElasticBunny/Types/Index.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace CodingBunny.ElasticBunny.Types;
+
+/// <summary>
+/// This class represents the base of the ElasticSearch index, and is used by the framework to enforce a few
+/// standards and constraints. Users of the framework should derive from this class, and implement their own
+/// Index representation to be serialized to JSON and sent to ElasticSearch.
+/// </summary>
+public abstract class Index
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="Index"/> class.
+    /// </summary>
+    /// <param name="name">The <see cref="IndexName"/> of the ElasticSearch Index.</param>
+    protected Index(IndexName name)
+    {
+        Name = name;
+    }
+    
+    /// <summary>
+    /// Gets the <see cref="IndexName"/> of the ElasticSearch Index.
+    /// </summary>
+    [JsonIgnore]
+    public IndexName Name { get; }
+}


### PR DESCRIPTION
## Summary
This pull request introduces the `Index` type to represent the index inside ElasticSearch.

Even though downstream consumers need to make their own implementations of the index that can be serialized to JSON, it's good to have a base class to start from. There is a given structure on the index for ElasticSearch that can be enforced from our side to avoid invalid data being submitted to the cluster.